### PR TITLE
Update loaders.py: Prediction - Data Loader Correction

### DIFF
--- a/ultralytics/data/loaders.py
+++ b/ultralytics/data/loaders.py
@@ -182,7 +182,7 @@ class LoadImages:
         parent = None
         if isinstance(path, str) and Path(path).suffix == '.txt':  # *.txt file with img/vid/dir on each line
             parent = Path(path).parent
-            path = Path(path).read_text().rsplit()
+            path = Path(path).read_text().splitlines() # Instead of rsplit() -> splitlines() Split lines ("\n") instead of all spaces (" ")
         files = []
         for p in sorted(path) if isinstance(path, (list, tuple)) else [path]:
             a = str(Path(p).absolute())  # do not use .resolve() https://github.com/ultralytics/ultralytics/issues/2912


### PR DESCRIPTION
Instead of using rsplit(), use splitlines(): Split lines ("\n") instead of all spaces (" ").

In the model JSON, the format for TXT files requires each file to be on separate lines. When performing a prediction using one of those .txt files, if the file names contain spaces (" "), they were being treated as two different files. For example, "example (1).JPG" would be treated as two files: "example" and "(1).JPG," resulting in an error and preventing successful file load.

With this modification, files will be read line by line. Therefore, a file name can include a space character (" ").